### PR TITLE
:arrow_up: Bump git-auto-commit-action to v7.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build package
         run: npm run package
       - name: Publish package
-        uses: stefanzweifel/git-auto-commit-action@v4.9.2
+        uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
           commit_message: ":rocket: Deploy new version [skip ci]"
           commit_user_name: Koj Bot


### PR DESCRIPTION
## Summary
- update Build CI from `stefanzweifel/git-auto-commit-action@v4.9.2` to `@v7.2.0`
- move the publish step from the legacy Node 12 action to the supported Node 24 runtime
- preserve the existing commit message and author inputs

## Test plan
- [x] Node 14.21.3 / npm 6.14.18 `npm ci`
- [x] `npm run build`
- [x] `npm test -- --runInBand` (2 suites, 2 tests)
- [x] `npm run package`
- [x] workflow YAML parse and actionlint

Supersedes #149.