### PR TITLE
:construction_worker: Support Dependabot in automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -12,6 +12,12 @@ on:
   pull_request_review:
     types:
       - submitted
+permissions:
+  checks: read
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: read
 jobs:
   automerge:
     runs-on: ubuntu-latest
@@ -19,7 +25,7 @@ jobs:
       - name: Automerge
         uses: pascalgn/automerge-action@v0.13.1
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GH_PAT || github.token }}"
           MERGE_LABELS: "merge,!work in progress,!wip"
           MERGE_REMOVE_LABELS: "merge"
           MERGE_METHOD: "merge"
@@ -32,4 +38,4 @@ jobs:
         with:
           branches: "!master, !production, *"
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GH_PAT || github.token }}"


### PR DESCRIPTION
## Summary
- fall back to the repository-scoped `github.token` when `GH_PAT` is unavailable to Dependabot
- declare the minimal workflow permissions needed by the merge and branch-cleanup actions
- keep `GH_PAT` as the preferred token for normal pull-request events

## Why
Fresh Dependabot PRs #159–#161 all reported red `Merge PRs` checks because Dependabot workflows cannot access Actions secrets, leaving `GITHUB_TOKEN` empty before the automerge action could evaluate labels. The fallback lets read-only Dependabot events complete safely instead of failing while preserving the existing PAT path for write operations.

## Test plan
- [x] Reproduced the failure from Actions logs (`environment variable GITHUB_TOKEN not set`)
- [x] Parsed all 12 workflow files as YAML
- [x] `actionlint` passes for `.github/workflows/automerge.yml`
- [x] Node 14.21.3 / npm 6.14.18: `npm ci`, `npm run build`, and `npm test -- --runInBand`
- [x] `git diff --check` and added-line security scan
