### PR TITLE
:construction_worker: Modernize CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,24 +2,28 @@ name: CodeQL CI
 on:
   schedule:
     - cron: "0 0 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
 jobs:
   release:
     name: Build and analyze
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v7
         with:
           node-version: 14
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v6
         env:
           cache-name: cache-node-modules
         with:
@@ -32,4 +36,4 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- replace the unsupported `ubuntu-18.04` runner with `ubuntu-latest`
- update CodeQL, checkout, setup-node, and cache actions to their current Node 24-compatible majors
- add least-privilege CodeQL permissions and a manual trigger for live verification

This supersedes the narrower CodeQL v1 → v4 update in #163.

## Test plan
- [x] Parse workflow YAML and assert triggers, permissions, runner, and action refs
- [x] `actionlint` passes
- [x] Node 14.21.3 / npm 6.14.18: `npm ci`
- [x] `npm run build`
- [x] `npm test -- --runInBand` (2 suites, 2 tests)
- [x] `npm run package`
- [x] `npm pack --dry-run`
- [x] `git diff --check` and added-line security scan

After merge, enable and dispatch CodeQL CI once to exercise the updated workflow on the default branch.