### PR TITLE
:construction_worker: Modernize release workflow runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     name: Build, test, and release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "contains(github.event.head_commit.message, 'Deploy new version')"
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 14
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v6
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
## Summary
- update the release job from the retired Ubuntu 18.04 runner to `ubuntu-latest`
- update `actions/cache` from v2 to v6 (Node 24 runtime)
- supersede Dependabot PR #161 with a branch based on current `master`

## Why
The one-line cache update in #161 is clean, but `actionlint` shows the surrounding release job still targets the unsupported `ubuntu-18.04` label. Updating both together keeps the new Node 24 action on a current runner and makes the release workflow runnable again.

## Test plan
- [x] YAML parse
- [x] `actionlint` on `.github/workflows/release.yml`
- [x] Node 14.21.3 / npm 6.14.18 `npm ci`
- [x] Jest (2 suites / 2 tests)
- [x] TypeScript build
- [x] ncc package build
- [x] `npm pack --dry-run`
- [x] staged diff and added-line security scan

Supersedes #161.
