### PR TITLE
:arrow_up: Bump actions/github-script from 8 to 9

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate branch name
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         id: set-branch-name
         with:
           script: |
@@ -41,7 +41,7 @@ jobs:
           PULL_REQUEST_TITLE: ${{ steps.set-branch-name.outputs.result }}
         run: printf 'PULL_REQUEST_TITLE=%s\n' "$PULL_REQUEST_TITLE" >> "$GITHUB_ENV"
       - name: Generate PR body
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         id: set-pr-body
         with:
           script: |
@@ -56,7 +56,7 @@ jobs:
           PULL_REQUEST_BODY: ${{ steps.set-pr-body.outputs.result }}
         run: printf 'PULL_REQUEST_BODY=%s\n' "$PULL_REQUEST_BODY" >> "$GITHUB_ENV"
       - name: Generate PR draft
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         id: set-pr-draft
         with:
           script: |
@@ -66,7 +66,7 @@ jobs:
           PULL_REQUEST_DRAFT: ${{ steps.set-pr-draft.outputs.result }}
         run: printf 'PULL_REQUEST_DRAFT=%s\n' "$PULL_REQUEST_DRAFT" >> "$GITHUB_ENV"
       - name: Determine whether to merge
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         id: should-pr
         with:
           github-token: ${{ secrets.GH_PAT || github.token }}
@@ -77,7 +77,7 @@ jobs:
               context.payload.ref.startsWith("refs/heads/bug")
             );
       - name: Create pull request
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         if: steps.should-pr.outputs.result == 'true'
         with:
           github-token: ${{ secrets.GH_PAT || github.token }}


### PR DESCRIPTION
## Summary
- updates all five PR Generator CI steps to `actions/github-script@v9`
- keeps the current script API usage intact; none imports or redeclares the v9-injected `getOctokit`
- replaces stale Dependabot PR #160 from current `master`

## Validation
- Node 12.22.12 / npm 6.14.16: `npm ci`, `npm run build`, and `npm test` (2 suites, 2 tests)
- Parsed the workflow YAML; actionlint passed; compiled all five `github-script` blocks against the v9 injected context
- `git diff --check` and added-line security scan passed
- Independent Codex review: passed with no security or logic findings

Supersedes #160.